### PR TITLE
Fixed 'y_is_date' in the templatetags.

### DIFF
--- a/demoproject/demoproject/templates/cumulativelinechart.html
+++ b/demoproject/demoproject/templates/cumulativelinechart.html
@@ -4,7 +4,7 @@
     <!-- load_nvd3 filter takes a comma-separated list of id's where -->
     <!-- the charts need to be rendered to                             -->
     {% include_nvd3jscss %}
-    {% load_chart charttype chartdata "cumulativelinechart_container" True %}
+    {% load_chart charttype chartdata "cumulativelinechart_container" "True" %}
 </head>
 <body>
     {% include_container "cumulativelinechart_container" 400 600 %}

--- a/demoproject/demoproject/templates/linechart.html
+++ b/demoproject/demoproject/templates/linechart.html
@@ -4,7 +4,7 @@
     <!-- load_nvd3 filter takes a comma-separated list of id's where -->
     <!-- the charts need to be rendered to                             -->
     {% include_nvd3jscss %}
-    {% load_chart charttype chartdata "linechart_container" True %}
+    {% load_chart charttype chartdata "linechart_container" "True" %}
 </head>
 <body>
     {% include_container "linechart_container" 400 600 %}

--- a/demoproject/demoproject/templates/lineplusbarchart.html
+++ b/demoproject/demoproject/templates/lineplusbarchart.html
@@ -4,7 +4,7 @@
     <!-- load_nvd3 filter takes a comma-separated list of id's where -->
     <!-- the charts need to be rendered to                             -->
     {% include_nvd3jscss %}
-    {% load_chart charttype chartdata "lineplusbarchart_container" True %}
+    {% load_chart charttype chartdata "lineplusbarchart_container" "True" %}
 </head>
 <body>
     {% include_container "lineplusbarchart_container" 400 600 %}

--- a/demoproject/demoproject/templates/linewithfocuschart.html
+++ b/demoproject/demoproject/templates/linewithfocuschart.html
@@ -4,7 +4,7 @@
     <!-- load_nvd3 filter takes a comma-separated list of id's where -->
     <!-- the charts need to be rendered to                             -->
     {% include_nvd3jscss %}
-    {% load_chart charttype chartdata "linewithfocuschart_container" True %}
+    {% load_chart charttype chartdata "linewithfocuschart_container" "True" %}
 </head>
 <body>
     {% include_container "linewithfocuschart_container" 400 '100%' %}


### PR DESCRIPTION
When passing a Boolean to a templatetag, it must be inside a string. 'True' instead of True.

This bug caused the charts to display dates incorrectly.
