### PR TITLE
Setup.py Error in Python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
 from setuptools import setup, find_packages
 import django_nvd3
 import os
-import codecs
 import re
 
 
 def read(*parts):
-    return codecs.open(os.path.join(os.path.dirname(__file__), *parts)).read()
+    return open(os.path.join(os.path.dirname(__file__), *parts)).read()
 
 
 def parse_requirements(file_name):


### PR DESCRIPTION
Setup.py was throwing the following error:

```
"TypeError: Type str doesn't support the buffer API"
```

Codecs returns a bytes object instead of a string object in Python3, and causes this error. This fix resolves this problem.
