### PR TITLE
Custom chart attributes support

### DIFF
--- a/django_nvd3/templatetags/nvd3_tags.py
+++ b/django_nvd3/templatetags/nvd3_tags.py
@@ -41,7 +41,7 @@ def load_chart(chart_type, series, container, kw_extra, *args, **kwargs):
     if not 'tag_script_js' in kw_extra:
         kw_extra['tag_script_js'] = True
     if not 'chart_attr' in kw_extra:
-        kw_extra['chart_attr'] = None
+        kw_extra['chart_attr'] = {}
     # set the container name
     kw_extra['name'] = container
 


### PR DESCRIPTION
This is related to (and requires) https://github.com/areski/python-nvd3/pull/24 in python-nvd3.

User can now pass custom chart attributes in extra.

Example:
xdata = [0.001, 0.01, 0.1, 1, 10, 100]
data = {   'charttype': charttype,
               'chartdata': chartdata,
               'chartcontainer': chartcontainer,
               'extra': {
                             'x_is_date': False,
                             'x_axis_format': '',
                             'tag_script_js': True,
                             'jquery_on_ready': False,
                             'chart_attr': { 'xScale':'(d3.scale.log())',
                                               'xAxis.tickValues':xdata },
                            }
               }

This allows user to display charts with a log scale on X axis, with the specified tick values.
