### PR TITLE
python3 - replace 'unicode' with 'str'

### DIFF
--- a/django_nvd3/templatetags/nvd3_tags.py
+++ b/django_nvd3/templatetags/nvd3_tags.py
@@ -45,7 +45,7 @@ def load_chart(chart_type, series, container, kw_extra={}, *args, **kwargs):
     if not 'chart_attr' in kw_extra:
         kw_extra['chart_attr'] = {}
     # set the container name
-    kw_extra['name'] = unicode(container)
+    kw_extra['name'] = str(container)
 
     # Build chart
     chart = eval(chart_type)(**kw_extra)
@@ -91,7 +91,7 @@ def include_container(include_container, height=400, width=600):
         * ``width`` - Chart width
     """
     chart = NVD3Chart()
-    chart.name = unicode(include_container)
+    chart.name = str(include_container)
     chart.set_graph_height(height)
     chart.set_graph_width(width)
     chart.buildcontainer()


### PR DESCRIPTION
Not sure if this change will work with python 2
