### PR TITLE
Add charset to js script tag as shown on http://d3js.org/;

### DIFF
--- a/django_nvd3/templatetags/nvd3_tags.py
+++ b/django_nvd3/templatetags/nvd3_tags.py
@@ -159,7 +159,7 @@ def include_chart_jscss(static_dir='', css_dir='', js_dir=''):
     ]
 
     chart.header_js = [
-        '<script src="%s" type="text/javascript"></script>\n' % h for h in
+        '<script src="%s" type="text/javascript" charset="utf-8"></script>\n' % h for h in
         (
             '%s%s' % (path, js_file) for js_file, path in js_files_dirs.items()
         )


### PR DESCRIPTION
see http://stackoverflow.com/a/29962882/4193.

Without this, browsers on Windows (tested with Chrome) report an error like this:

"Uncaught ReferenceError: d3 is not defined(anonymous function) @ nv.d3.min.js:2(anonymous function) @ nv.d3.min.js:7"