### PR TITLE
Fix issue #63 by properly ordering the inclusion of static files

### DIFF
--- a/django_nvd3/templatetags/nvd3_tags.py
+++ b/django_nvd3/templatetags/nvd3_tags.py
@@ -1,3 +1,5 @@
+import collections
+
 from django.template.defaultfilters import register
 from django.utils.safestring import mark_safe
 from django.conf import settings
@@ -130,8 +132,8 @@ def include_chart_jscss(static_dir='', css_dir='', js_dir=''):
     if static_dir:
         static_dir += '/'
 
-    css_files_dirs = {}
-    js_files_dirs = {}
+    css_files_dirs = collections.OrderedDict()
+    js_files_dirs = collections.OrderedDict()
 
     css_files_dirs['nv.d3.min.css'] = '%s%snvd3/build/' % (settings.STATIC_URL, static_dir)
 


### PR DESCRIPTION
We include the static files by iterating over css_files_dirs.items() and
js_files_dirs.items(). d3.js should always be included before nvd3.js. Use
an OrderedDict instead of the normal dictionary to enforce the correct order.