### PR TITLE
Fixed missing file in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ include README.rst
 include CHANGELOG.rst
 include MIT-LICENSE.txt
 include requirements.txt
+include test-requirements.txt
 recursive-include django_nvd3 *


### PR DESCRIPTION
Having issues trying to install this django-nvd3 and I believe it was caused by your earlier commit: 3453d7d

`test-requirements.txt` is missing from the `MANIFEST.in` so I've added it