### PR TITLE
Fixed UnicodeDecodeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import re
 
 def get_version(filename="django_nvd3/__init__.py", varname="__version__"):
     glb = {}
-    with open(filename) as fp:
+    with open(filename, 'rt', encoding='utf8') as fp:
         for line in fp:
             if varname in line:
                 exec(line, glb)
@@ -13,7 +13,7 @@ def get_version(filename="django_nvd3/__init__.py", varname="__version__"):
 
 
 def readfile(filename):
-    with open(filename) as fp:
+    with open(filename, 'rt', encoding='utf8') as fp:
         return fp.read()
 
 


### PR DESCRIPTION
The `README.rst` document contains non-ascii characters.
The `README.rst` document is in UTF8 encoding.

On Korean Windows, `open` will use cp949 encoding. Thus, UnicodeDecodeError is raised.