### PR TITLE
Fixed UnicodeDecodeError while installing package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 from setuptools import setup, find_packages
+from io import open
 import re
 
 
 def get_version(filename="django_nvd3/__init__.py", varname="__version__"):
     glb = {}
-    with open(filename) as fp:
+    with open(filename, encoding='utf-8') as fp:
         for line in fp:
             if varname in line:
                 exec(line, glb)
@@ -13,7 +14,7 @@ def get_version(filename="django_nvd3/__init__.py", varname="__version__"):
 
 
 def readfile(filename):
-    with open(filename) as fp:
+    with open(filename, encoding='utf-8') as fp:
         return fp.read()
 
 


### PR DESCRIPTION
At Korean Windows, setup.py raises **UnicodeDecodeError** because of '**cp949**' encoding.
So I'm using `open` from `io` instead of builtins `open`.

https://docs.python.org/2/library/io.html
https://docs.python.org/3.5/library/io.html

Thanks.


