### PR TITLE
boost python-nvd3 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-nvd3==0.14.2
+python-nvd3>=0.14.2


### PR DESCRIPTION
Allow boost python-nvd3 to version  0.15.0 which allows to use 'python-slugify>=1.2.5', and not only 'python-slugify==1.1.4',
This ensures compatibility with other libraries which has higher version of this library.
