### PR TITLE
fix package (where templatetags were not included)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     author_email='areski@gmail.com',
     license='MIT',
     zip_safe=False,
-    packages=["django_nvd3"],
+    packages=find_packages(include=['django_nvd3', 'django_nvd3.*']),
     install_requires=["Django", "python-nvd3"],
     test_suite='tests',
     classifiers=[


### PR DESCRIPTION
@areski Hope this fixes the package. If I run `python setup.py build`, the `templatetags` will end up in the `build` directory.